### PR TITLE
Feat/9 히스토리 리스트 구현

### DIFF
--- a/app/src/main/java/com/termproject/sprintyou/ui/history/CalendarActivity.kt
+++ b/app/src/main/java/com/termproject/sprintyou/ui/history/CalendarActivity.kt
@@ -2,137 +2,47 @@ package com.termproject.sprintyou.ui.history
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import com.prolificinteractive.materialcalendarview.CalendarDay
-import com.prolificinteractive.materialcalendarview.DayViewDecorator
-import com.prolificinteractive.materialcalendarview.DayViewFacade
-import com.prolificinteractive.materialcalendarview.spans.DotSpan
-import com.termproject.sprintyou.R
-import com.termproject.sprintyou.data.SprintDatabaseProvider
-import com.termproject.sprintyou.data.SprintHistoryItem
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayoutMediator
 import com.termproject.sprintyou.databinding.ActivityCalendarBinding
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 class CalendarActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityCalendarBinding
-    private val adapter = HistoryAdapter()
-    private val database by lazy { SprintDatabaseProvider.getDatabase(this) }
-    private val zoneId: ZoneId = ZoneId.systemDefault()
-    private var monthRecords: List<SprintHistoryItem> = emptyList()
-    private var dotDecorator: SprintDotDecorator? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityCalendarBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        setupRecycler()
-        bindCalendar()
+        setupViewPager()
+        
         binding.btnBack.setOnClickListener { finish() }
     }
 
-    override fun onResume() {
-        super.onResume()
-        val today = LocalDate.now()
-        val todayCalendarDay = today.toCalendarDay()
-        binding.calendarView.setCurrentDate(todayCalendarDay)
-        binding.calendarView.selectedDate = todayCalendarDay
-        loadMonth(today)
+    private fun setupViewPager() {
+        val adapter = HistoryPagerAdapter(this)
+        binding.viewPager.adapter = adapter
+
+        TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->
+            tab.text = when (position) {
+                0 -> "캘린더"
+                1 -> "목표 달성"
+                else -> ""
+            }
+        }.attach()
     }
 
-    private fun setupRecycler() {
-        binding.rvHistory.layoutManager = LinearLayoutManager(this)
-        binding.rvHistory.adapter = adapter
-    }
+    private inner class HistoryPagerAdapter(activity: AppCompatActivity) : FragmentStateAdapter(activity) {
+        override fun getItemCount(): Int = 2
 
-    private fun bindCalendar() {
-        binding.calendarView.setOnMonthChangedListener { _, date ->
-            loadMonth(date.toLocalDate())
-        }
-        binding.calendarView.setOnDateChangedListener { _, date, selected ->
-            if (selected) {
-                showRecordsFor(date.toLocalDate())
+        override fun createFragment(position: Int): Fragment {
+            return when (position) {
+                0 -> CalendarFragment()
+                1 -> GoalListFragment()
+                else -> throw IllegalArgumentException("Invalid position: $position")
             }
         }
-    }
-
-    private fun loadMonth(date: LocalDate) {
-        val firstDay = date.withDayOfMonth(1)
-        val lastDay = firstDay.plusMonths(1).minusDays(1)
-        val startMillis = firstDay.atStartOfDay(zoneId).toInstant().toEpochMilli()
-        val endMillis = lastDay.plusDays(1).atStartOfDay(zoneId).toInstant().minusMillis(1).toEpochMilli()
-
-        lifecycleScope.launch {
-            val records = withContext(Dispatchers.IO) {
-                database.sprintRecordDao().getBetween(startMillis, endMillis)
-            }
-            monthRecords = records
-            updateDecorators(records)
-            val selectedDate = binding.calendarView.selectedDate?.toLocalDate() ?: firstDay
-            showRecordsFor(selectedDate.coerceIn(firstDay, lastDay))
-        }
-    }
-
-    private fun updateDecorators(records: List<SprintHistoryItem>) {
-        dotDecorator?.let { binding.calendarView.removeDecorator(it) }
-        val dates = records
-            .map { it.record.createdAt.toLocalDate() }
-            .map { it.toCalendarDay() }
-            .toSet()
-
-        val color = ContextCompat.getColor(this, R.color.secondary_blue)
-        val decorator = SprintDotDecorator(dates, color)
-        binding.calendarView.addDecorator(decorator)
-        dotDecorator = decorator
-    }
-
-    private fun showRecordsFor(date: LocalDate) {
-        val filtered = monthRecords.filter { it.record.createdAt.toLocalDate() == date }
-        adapter.submitList(filtered)
-        binding.tvSelectedDate.text = date.format(DATE_FORMATTER)
-        binding.tvEmptyState.isVisible = filtered.isEmpty()
-        binding.rvHistory.isVisible = filtered.isNotEmpty()
-    }
-
-    private fun Long.toLocalDate(): LocalDate =
-        Instant.ofEpochMilli(this).atZone(zoneId).toLocalDate()
-
-    private fun LocalDate.coerceIn(min: LocalDate, max: LocalDate): LocalDate =
-        when {
-            this.isBefore(min) -> min
-            this.isAfter(max) -> max
-            else -> this
-        }
-
-    private fun CalendarDay.toLocalDate(): LocalDate =
-        LocalDate.of(year, month + 1, day)
-
-    private fun LocalDate.toCalendarDay(): CalendarDay =
-        CalendarDay.from(year, monthValue - 1, dayOfMonth)
-
-    private class SprintDotDecorator(
-        private val dates: Set<CalendarDay>,
-        private val color: Int
-    ) : DayViewDecorator {
-        override fun shouldDecorate(day: CalendarDay): Boolean = dates.contains(day)
-        override fun decorate(view: DayViewFacade) {
-            view.addSpan(DotSpan(8f, color))
-        }
-    }
-
-    companion object {
-        private val DATE_FORMATTER: DateTimeFormatter =
-            DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.getDefault())
     }
 }

--- a/app/src/main/java/com/termproject/sprintyou/ui/history/GoalExpandableAdapter.kt
+++ b/app/src/main/java/com/termproject/sprintyou/ui/history/GoalExpandableAdapter.kt
@@ -1,0 +1,136 @@
+package com.termproject.sprintyou.ui.history
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import com.termproject.sprintyou.data.MainGoal
+import com.termproject.sprintyou.data.SprintRecord
+import com.termproject.sprintyou.databinding.ItemGoalHeaderBinding
+import com.termproject.sprintyou.databinding.ItemSprintChildBinding
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+data class GoalWithSprints(
+    val goal: MainGoal,
+    val sprints: List<SprintRecord>,
+    var isExpanded: Boolean = false
+)
+
+class GoalExpandableAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private val items = mutableListOf<Any>()
+    private var data: List<GoalWithSprints> = emptyList()
+
+    fun submitList(newData: List<GoalWithSprints>) {
+        data = newData
+        rebuildList()
+    }
+
+    private fun rebuildList() {
+        items.clear()
+        data.forEach { goalData ->
+            items.add(goalData)
+            if (goalData.isExpanded) {
+                items.addAll(goalData.sprints)
+            }
+        }
+        notifyDataSetChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (items[position]) {
+            is GoalWithSprints -> TYPE_HEADER
+            is SprintRecord -> TYPE_CHILD
+            else -> throw IllegalArgumentException("Invalid item type")
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            TYPE_HEADER -> HeaderViewHolder(
+                ItemGoalHeaderBinding.inflate(inflater, parent, false)
+            )
+            TYPE_CHILD -> ChildViewHolder(
+                ItemSprintChildBinding.inflate(inflater, parent, false)
+            )
+            else -> throw IllegalArgumentException("Invalid view type")
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is HeaderViewHolder -> holder.bind(items[position] as GoalWithSprints)
+            is ChildViewHolder -> holder.bind(items[position] as SprintRecord)
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    inner class HeaderViewHolder(private val binding: ItemGoalHeaderBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.root.setOnClickListener {
+                val position = adapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    val item = items[position] as? GoalWithSprints ?: return@setOnClickListener
+                    item.isExpanded = !item.isExpanded
+                    // In a real optimized list, we would use notifyItemRangeInserted/Removed
+                    // But for simplicity, we rebuild
+                    rebuildList()
+                }
+            }
+        }
+
+        @SuppressLint("SetTextI18n")
+        fun bind(item: GoalWithSprints) {
+            binding.tvGoalTitle.text = item.goal.title
+            binding.tvStatus.text = "${item.goal.status.name} • ${formatDate(item.goal.createdAt)}"
+            binding.tvCountBadge.text = item.sprints.size.toString()
+            binding.ivArrow.rotation = if (item.isExpanded) 180f else 0f
+            binding.tvCountBadge.isVisible = item.sprints.isNotEmpty()
+        }
+
+        private fun formatDate(timestamp: Long): String {
+            return Instant.ofEpochMilli(timestamp)
+                .atZone(ZoneId.systemDefault())
+                .format(DATE_FORMATTER)
+        }
+    }
+
+    inner class ChildViewHolder(private val binding: ItemSprintChildBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: SprintRecord) {
+            binding.tvTaskContent.text = item.taskContent
+            binding.tvDate.text = formatDateTime(item.createdAt)
+            binding.tvDuration.text = formatDuration(item.actualDurationSeconds)
+        }
+
+        @SuppressLint("DefaultLocale")
+        private fun formatDuration(seconds: Long): String {
+            val minutes = seconds / 60
+            val remainingSeconds = seconds % 60
+            return String.format("%d분 %02d초", minutes, remainingSeconds)
+        }
+
+        private fun formatDateTime(timestamp: Long): String {
+            return Instant.ofEpochMilli(timestamp)
+                .atZone(ZoneId.systemDefault())
+                .format(DATETIME_FORMATTER)
+        }
+    }
+
+    companion object {
+        private const val TYPE_HEADER = 0
+        private const val TYPE_CHILD = 1
+
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.getDefault())
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("M월 d일 a h:mm", Locale.getDefault())
+    }
+}

--- a/app/src/main/java/com/termproject/sprintyou/ui/history/GoalListFragment.kt
+++ b/app/src/main/java/com/termproject/sprintyou/ui/history/GoalListFragment.kt
@@ -1,0 +1,29 @@
+package com.termproject.sprintyou.ui.history
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.termproject.sprintyou.databinding.FragmentGoalListBinding
+
+class GoalListFragment : Fragment() {
+
+    private var _binding: FragmentGoalListBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentGoalListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}
+

--- a/app/src/main/java/com/termproject/sprintyou/ui/history/GoalListFragment.kt
+++ b/app/src/main/java/com/termproject/sprintyou/ui/history/GoalListFragment.kt
@@ -4,13 +4,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.termproject.sprintyou.data.SprintDatabaseProvider
 import com.termproject.sprintyou.databinding.FragmentGoalListBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class GoalListFragment : Fragment() {
 
     private var _binding: FragmentGoalListBinding? = null
     private val binding get() = _binding!!
+    private val adapter = GoalExpandableAdapter()
+    private val database by lazy { SprintDatabaseProvider.getDatabase(requireContext()) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -21,9 +30,40 @@ class GoalListFragment : Fragment() {
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        
+        binding.rvGoalList.layoutManager = LinearLayoutManager(context)
+        binding.rvGoalList.adapter = adapter
+        binding.tvComingSoon.isVisible = false
+        
+        loadData()
+    }
+
+    private fun loadData() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val goalsWithSprints = withContext(Dispatchers.IO) {
+                val goals = database.mainGoalDao().getAllGoals()
+                val sprints = database.sprintRecordDao().getAllRecords()
+
+                val sprintMap = sprints.groupBy { it.parentGoalId }
+                
+                goals.map { goal ->
+                    GoalWithSprints(
+                        goal = goal,
+                        sprints = sprintMap[goal.goalId] ?: emptyList()
+                    )
+                }
+            }
+            
+            adapter.submitList(goalsWithSprints)
+            binding.tvComingSoon.isVisible = goalsWithSprints.isEmpty()
+            binding.tvComingSoon.text = "아직 등록된 목표가 없습니다."
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
     }
 }
-

--- a/app/src/main/res/drawable/bg_badge.xml
+++ b/app/src/main/res/drawable/bg_badge.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorPrimary" />
+    <corners android:radius="12dp" />
+    <padding
+        android:bottom="2dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="2dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6l-6,-6l1.41,-1.41z" />
+</vector>

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -5,13 +5,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface"
-    android:padding="24dp"
     tools:context=".ui.history.CalendarActivity">
 
     <ImageButton
         android:id="@+id/btn_back"
         android:layout_width="40dp"
         android:layout_height="40dp"
+        android:layout_margin="24dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/desc_back"
         android:padding="8dp"
@@ -29,56 +29,29 @@
         android:textAppearance="?attr/textAppearanceHeadlineSmall"
         android:textColor="?attr/colorOnSurface"
         app:layout_constraintBottom_toBottomOf="@id/btn_back"
-        app:layout_constraintStart_toEndOf="@id/btn_back" />
+        app:layout_constraintStart_toEndOf="@id/btn_back"
+        app:layout_constraintTop_toTopOf="@id/btn_back" />
 
-    <com.prolificinteractive.materialcalendarview.MaterialCalendarView
-        android:id="@+id/calendar_view"
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="8dp"
+        android:background="?attr/colorSurface"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/btn_back"
-        app:mcv_showOtherDates="all"
-        app:mcv_selectionColor="?attr/colorPrimary"
-        app:mcv_tileHeight="48dp"
-        tools:layout_height="360dp" />
+        app:tabIndicatorColor="?attr/colorPrimary"
+        app:tabSelectedTextColor="?attr/colorPrimary"
+        app:tabTextColor="?attr/colorOnSurfaceVariant" />
 
-    <TextView
-        android:id="@+id/tv_selected_date"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:textAppearance="?attr/textAppearanceTitleMedium"
-        android:textColor="?attr/colorOnSurface"
-        tools:text="12월 1일 (월)"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/calendar_view" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_history"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_selected_date"
-        tools:listitem="@layout/item_history" />
-
-    <TextView
-        android:id="@+id/tv_empty_state"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/calendar_empty"
-        android:textAppearance="?attr/textAppearanceBodyLarge"
-        android:textColor="?attr/colorOnSurfaceVariant"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_selected_date" />
+        app:layout_constraintTop_toBottomOf="@id/tab_layout" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
-

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -57,4 +57,3 @@
         app:layout_constraintTop_toBottomOf="@id/tv_selected_date" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
-

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
+    android:padding="24dp">
+
+    <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+        android:id="@+id/calendar_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:mcv_showOtherDates="all"
+        app:mcv_selectionColor="?attr/colorPrimary"
+        app:mcv_tileHeight="48dp"
+        tools:layout_height="360dp" />
+
+    <TextView
+        android:id="@+id/tv_selected_date"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textColor="?attr/colorOnSurface"
+        tools:text="12월 1일 (월)"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/calendar_view" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_history"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_selected_date"
+        tools:listitem="@layout/item_history" />
+
+    <TextView
+        android:id="@+id/tv_empty_state"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/calendar_empty"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_selected_date" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/layout/fragment_goal_list.xml
+++ b/app/src/main/res/layout/fragment_goal_list.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/tv_goal_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="목표 및 스프린트 달성 현황"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textColor="?attr/colorOnSurface"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- Placeholder for Expandable List -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_goal_list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_goal_title" />
+
+    <TextView
+        android:id="@+id/tv_coming_soon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="목표별 달성 현황 기능 준비중입니다."
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/layout/item_goal_header.xml
+++ b/app/src/main/res/layout/item_goal_header.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tv_goal_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textColor="?attr/colorOnSurface"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@id/tv_count_badge"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="다이어트" />
+
+    <TextView
+        android:id="@+id/tv_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        app:layout_constraintStart_toStartOf="@id/tv_goal_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_goal_title"
+        tools:text="진행중 • 2024.12.01 시작" />
+
+    <TextView
+        android:id="@+id/tv_count_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/bg_badge"
+        android:gravity="center"
+        android:minWidth="24dp"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="2dp"
+        android:textAppearance="?attr/textAppearanceLabelSmall"
+        android:textColor="?attr/colorOnPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/iv_arrow"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="5" />
+
+    <ImageView
+        android:id="@+id/iv_arrow"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/ic_arrow_down"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/colorOnSurfaceVariant" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_sprint_child.xml
+++ b/app/src/main/res/layout/item_sprint_child.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorSurface"
+    android:paddingStart="32dp"
+    android:paddingTop="12dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="12dp">
+
+    <View
+        android:id="@+id/view_line"
+        android:layout_width="2dp"
+        android:layout_height="0dp"
+        android:background="?attr/colorOutlineVariant"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_task_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="8dp"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?attr/colorOnSurface"
+        app:layout_constraintEnd_toStartOf="@id/tv_duration"
+        app:layout_constraintStart_toEndOf="@id/view_line"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="오늘의 운동 완료" />
+
+    <TextView
+        android:id="@+id/tv_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="4dp"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/view_line"
+        app:layout_constraintTop_toBottomOf="@id/tv_task_content"
+        tools:text="12월 5일 오후 3:30" />
+
+    <TextView
+        android:id="@+id/tv_duration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceLabelMedium"
+        android:textColor="?attr/colorPrimary"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/tv_date"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_task_content"
+        tools:text="25분 00초" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 연관된 이슈

> Closes: #9 

## 작업 상세

- 히스토리 화면을 리스트, 캘린더로 분할 
  -> fragmentation
- 리스트는 계층형 목표로 진행률과 완료된 스프린트를 모아볼 수 있게 확장형으로 구성